### PR TITLE
Truncate microseconds by setting to 0

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -343,7 +343,7 @@ class croniter(object):
                     break
             if next:
                 continue
-            return self._datetime_to_timestamp(dst)
+            return self._datetime_to_timestamp(dst.replace(microsecond=0))
 
         raise Exception("failed to find prev date")
 


### PR DESCRIPTION
To maintain backwards compatible behavior and comparability of time
values returned by croniter, truncate microseconds from return value
of get_(prev|next) by setting it to 0.

Commit f7e14967 replaced `mktime(dst.timetuple())`, which truncates
microseconds as timetuple() omits microseconds, with
`self._datetime_to_timestamp(dst)` which maintains microseconds.  This
commit sets microseconds to 0, effectively truncating microseconds as
was done previously.

Always setting microseconds to 0 is inline with the maintained
behavior of settings seconds to 0 when the cron format omits seconds
(ie 5 column cron format) as the cron format always omits
microseconds.

Currently time values returned by croniter are not easily compared
when the start time differs, if only in microseconds, because the
start time's microseconds are maintained in the output of
get_(prev|next).  The start time commonly differs when the time value
is communicated between application executions (eg in a database) or
between different applications (eg over the network).  So restoring
the previous behavior not only restores backwards compatibility, but
also restores the ability to compare croniter time values.