### PR TITLE
The functionality of 'l' as day of month was broken

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -350,6 +350,7 @@ class croniter(object):
             for proc in procs:
                 (changed, dst) = proc(dst)
                 if changed:
+                    day, month, year = dst.day, dst.month, dst.year
                     next = True
                     break
             if next:

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -164,6 +164,22 @@ class CroniterTest(base.TestCase):
         self.assertEqual(n4.month, 1)
         self.assertEqual(n4.year, 2011)
 
+    def testLastDayOfMonth(self):
+        base = datetime(2015, 9, 4)
+        itr = croniter('0 0 l * *', base)
+        n1 = itr.get_next(datetime)
+        self.assertEqual(n1.month, 9)
+        self.assertEqual(n1.day, 30)
+        n2 = itr.get_next(datetime)
+        self.assertEqual(n2.month, 10)
+        self.assertEqual(n2.day, 31)
+        n3 = itr.get_next(datetime)
+        self.assertEqual(n3.month, 11)
+        self.assertEqual(n3.day, 30)
+        n4 = itr.get_next(datetime)
+        self.assertEqual(n4.month, 12)
+        self.assertEqual(n4.day, 31)
+
     def testError(self):
         itr = croniter('* * * * *')
         self.assertRaises(TypeError, itr.get_next, str)


### PR DESCRIPTION
The functionality of 'l' as day of month was broken since the month variable was not properly updated. See the test the that was added.