### PR TITLE
Update setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     packages=find_packages('src'),
     package_dir={'': 'src'},


### PR DESCRIPTION
The changelog suggests croniter supports Python 3.
The classifiers are used by PyPI to recognize Python 3 compatible packages (also by caniusepython3.com and developers).