### PR TITLE
support setting ret_type in __init__

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -52,7 +52,8 @@ class croniter(object):
     bad_length = 'Exactly 5 or 6 columns has to be specified for iterator' \
                  'expression.'
 
-    def __init__(self, expr_format, start_time=None):
+    def __init__(self, expr_format, start_time=None, ret_type=float):
+        self._ret_type = ret_type
         if start_time is None:
             start_time = time()
 
@@ -137,13 +138,14 @@ class croniter(object):
                             else res)
         self.expanded = expanded
 
-    def get_next(self, ret_type=float):
-        return self._get_next(ret_type, is_prev=False)
+    def get_next(self, ret_type=None):
+        return self._get_next(ret_type or self._ret_type, is_prev=False)
 
-    def get_prev(self, ret_type=float):
-        return self._get_next(ret_type, is_prev=True)
+    def get_prev(self, ret_type=None):
+        return self._get_next(ret_type or self._ret_type, is_prev=True)
 
-    def get_current(self, ret_type=float):
+    def get_current(self, ret_type=None):
+        ret_type = ret_type or self._ret_type
         if ret_type == datetime.datetime:
             return self._timestamp_to_datetime(self.cur)
         return self.cur
@@ -186,23 +188,25 @@ class croniter(object):
         return self
     __next__ = next = get_next
 
-    def all_next(self, ret_type=float):
+    def all_next(self, ret_type=None):
         '''Generator of all consecutive dates. Can be used instead of
         implicit call to __iter__, whenever non-default
         'ret_type' has to be specified.
         '''
         while True:
-            yield self._get_next(ret_type, is_prev=False)
+            yield self._get_next(ret_type or self._ret_type, is_prev=False)
 
-    def all_prev(self, ret_type=float):
+    def all_prev(self, ret_type=None):
         '''Generator of all previous dates.'''
         while True:
-            yield self._get_next(ret_type, is_prev=True)
+            yield self._get_next(ret_type or self._ret_type, is_prev=True)
 
     iter = all_next  # alias, you can call .iter() instead of .all_next()
 
-    def _get_next(self, ret_type=float, is_prev=False):
+    def _get_next(self, ret_type=None, is_prev=False):
         expanded = self.expanded[:]
+
+        ret_type = ret_type or self._ret_type
 
         if ret_type not in (float, datetime.datetime):
             raise TypeError("Invalid ret_type, only 'float' or 'datetime' "


### PR DESCRIPTION
With the current interface, it's impossible to get back datetime instances when using croniter as an iterator.  The get_next and get_prev functions will let you pass a ret_type, but you can't get a datetime back if just doing [x for x in my_croniter].

This modification allows setting ret_type when instantiating the class, so you can get back datetimes when using croniter as a plain iterator.  Passing in a type of your choice to get_next and get_prev is still supported, and overrides the ret_type set on init.