### PR TITLE
Update __init__.py

### DIFF
--- a/src/croniter/__init__.py
+++ b/src/croniter/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from .croniter import (
     croniter,
+    CroniterError,  # noqa
     CroniterBadDateError,  # noqa
     CroniterBadCronError,  # noqa
     CroniterNotAlphaError  # noqa


### PR DESCRIPTION
Support for importing `CroniterError` as a catch-all for errors raised by croniter.