### PR TITLE
Add last day of month example to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ A simple example::
     >>> iter = croniter('0 0 * * sat#1,sun#2', base)
     >>> print(iter.get_next(datetime))   # datetime.datetime(2010, 2, 6, 0, 0)
 
+    >>> iter = croniter('59 23 L * *', base)  # 23:59 on last day of the month
+    >>> print(iter.get_next(datetime))  2010-01-31 23:59:00
+    >>> print(iter.get_next(datetime))  2010-02-28 23:59:00
+    >>> print(iter.get_next(datetime))  2010-03-31 23:59:00
+
 All you need to know is how to use the constructor and the ``get_next``
 method, the signature of these methods are listed below::
 


### PR DESCRIPTION
This commit adds an example to the documentation for a cron job that runs on the last day of every month. I recently found a need for this and it took a bit of digging to find that it is easily handled.