### PR TITLE
Minor DST unittest tweak

### DIFF
--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1018,7 +1018,7 @@ class CroniterTest(base.TestCase):
             itt.get_next(datetime).isoformat(),
             itt.get_next(datetime).isoformat(),
         ]
-        self.assertEqual(ret, [
+        self.assertEqual(rett, [
             '2020-03-30T02:01:00+02:00',
             '2020-03-29T01:01:00+01:00',
             '2020-03-28T03:01:00+01:00',


### PR DESCRIPTION
Minor variable mixup in a unit test.  This doesn't impact the result at this time, but it ensure the correct variable is tested.