### PR TITLE
Add dateutil unittests & docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /venv
 /.cache
 .idea
+*.py,cover
+.coverage
+.python-version

--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,22 @@ You can validate your crons using ``is_valid`` class method. (>= 0.3.18)::
 
 About DST
 =========
-Be sure to init your croniter instance with a TZ aware datetime for this to work !::
+Be sure to init your croniter instance with a TZ aware datetime for this to work!
 
+Example using pytz::
+
+    >>> import pytz
+    >>> tz = pytz.timezone("Europe/Paris")
     >>> local_date = tz.localize(datetime(2017, 3, 26))
     >>> val = croniter('0 0 * * *', local_date).get_next(datetime)
+
+Example using python_dateutil::
+
+    >>> import dateutil.tz
+    >>> tz = dateutil.tz.gettz('Asia/Tokyo')
+    >>> local_date = datetime(2017, 3, 26, tzinfo=tz)
+    >>> val = croniter('0 0 * * *', local_date).get_next(datetime)
+
 
 About second repeats
 =====================

--- a/README.rst
+++ b/README.rst
@@ -118,14 +118,14 @@ Croniter is able to do second repeatition crontabs form::
     >>> itr.get_next(datetime) # 4/6 13:26:25
     >>> itr.get_next(datetime) # 4/6 13:27:15
 
-You can also note that this expression will repeat every second from the start datetime.
+You can also note that this expression will repeat every second from the start datetime.::
 
     >>> croniter('* * * * * *', local_date).get_next(datetime)
 
 Testing if a date matchs a crontab
 ==================================
-As simple as::
- 
+Test for a match with (>=0.3.32)::
+
     >>> croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 0, 0, 0))
     True
     >>> croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 2, 0, 0))

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -57,7 +57,7 @@ Changelog
 0.3.23 (2018-05-23)
 -------------------
 
-- fix `get_next` while perserving the fix of `get_prev` in 7661c2aaa
+- fix ``get_next`` while perserving the fix of ``get_prev`` in 7661c2aaa
   [Avikam Agur <avikam@pagaya-inv.com>]
 
 
@@ -65,7 +65,7 @@ Changelog
 -------------------
 - Don't count previous minute if now is dynamic
   If the code is triggered from 5-asterisk based cron
-  `get_prev` based on `datetime.now()` is expected to return
+  ``get_prev`` based on ``datetime.now()`` is expected to return
   current cron iteration and not previous execution.
   [Igor Khrol <igor.khrol@toptal.com>]
 
@@ -175,7 +175,7 @@ Changelog
 ------------------
 
 - Fix default behavior when no start_time given
-  Default value for `start_time` parameter is calculated at module init time rather than call time.
+  Default value for ``start_time`` parameter is calculated at module init time rather than call time.
 - Fix timezone support and stop depending on the system time zone
 
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -9,6 +9,7 @@ import pytz
 from croniter import croniter, CroniterBadDateError, CroniterBadCronError, CroniterNotAlphaError
 from croniter.tests import base
 from tzlocal import get_localzone
+import dateutil.tz
 
 
 class CroniterTest(base.TestCase):
@@ -649,6 +650,13 @@ class CroniterTest(base.TestCase):
         itr2 = croniter('* * * * *', tokyo.localize(base))
         n2 = itr2.get_next(datetime)
         self.assertEqual(n2.tzinfo.zone, 'Asia/Tokyo')
+
+    def testTimezoneDateutil(self):
+        tokyo = dateutil.tz.gettz('Asia/Tokyo')
+        base = datetime(2013, 3, 4, 12, 15, tzinfo=tokyo)
+        itr = croniter('* * * * *', base)
+        n1 = itr.get_next(datetime)
+        self.assertEqual(n1.tzinfo.tzname(n1), 'JST')
 
     def testInitNoStartTime(self):
         itr = croniter('* * * * *')


### PR DESCRIPTION
I added a single unit test with a dateutil timezone and expanded the Timezone/DST section in the README.  (I have a few more unittest locally, but they are DST related breaks.  I didn't want to push failing unit tests, but can provide them if you'd like.)

There's also some other random cleanup/grooming items in here.  I tried to split things out into logical commits to make reverting any of them easier.