### PR TITLE
Feat croniter_range(start, stop, cron)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ Test for a match with (>=0.3.32)::
 Iterating over a range using cron
 =================================
 Finding all matching times in at time range can be handled with the ``croniter_range()`` function.  This is much like the builtin ``range(start,stop,step)`` function, but for dates using a cron expression as "step".
-Added in (>=0.3.XX)
+Added in (>=0.3.34)
 
 List the first Saturday of every month in 2019::
 

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,18 @@ Test for a match with (>=0.3.32)::
     >>> croniter.match("2 4 1 * wed", datetime(2019, 1, 1, 4, 2, 0, 0), day_or=False) # 04:02 on every 1st day of the month if it is a Wednesday
     False
 
+
+Iterating over a range using cron
+=================================
+Finding all matching times in at time range can be handled with the ``croniter_range()`` function.  This is much like the builtin ``range(start,stop,step)`` function, but for dates using a cron expression as "step".
+Added in (>=0.3.XX)
+
+List the first Saturday of every month in 2019::
+
+    >>> from croniter import croniter_range
+    >>> for dt in croniter_range(datetime(2019, 1, 1), datetime(2019, 12, 31), "0 0 * * sat#1"):
+    >>>     print(dt)
+
 Develop this package
 ====================
 

--- a/src/croniter/__init__.py
+++ b/src/croniter/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from .croniter import (
     croniter,
+    croniter_range,
     CroniterBadDateError,  # noqa
     CroniterBadCronError,  # noqa
     CroniterNotAlphaError  # noqa

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -610,10 +610,6 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
     if isinstance(start, (float, int)):
         start, stop = (datetime.datetime.utcfromtimestamp(t) for t in (start, stop))
         auto_rt = float
-    elif isinstance(start, datetime.datetime) and isinstance(stop, datetime.datetime):
-        if start.tzinfo is not stop.tzinfo:
-            raise ValueError("The start and stop timezone must be the same.  {0} != {1}"
-                             .format(start.tzinfo, stop.tzinfo))
     if ret_type is None:
         ret_type = auto_rt
     if not exclude_ends:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -610,7 +610,7 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
     if isinstance(start, (float, int)):
         start, stop = (datetime.datetime.utcfromtimestamp(t) for t in (start, stop))
         auto_rt = float
-    elif issubclass(type(start), datetime.datetime) and issubclass(type(stop), datetime.datetime):
+    elif isinstance(start, datetime.datetime) and isinstance(stop, datetime.datetime):
         if start.tzinfo is not stop.tzinfo:
             raise ValueError("The start and stop timezone must be the same.  {0} != {1}"
                              .format(start.tzinfo, stop.tzinfo))
@@ -625,6 +625,7 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
             start += ms1
             stop -= ms1
     ic = croniter(expr_format, start, ret_type=datetime.datetime, day_or=day_or)
+    # define a continue (cont) condition function and step function for the main while loop
     if start < stop:        # Forward
         def cont(v):
             return v < stop

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1103,6 +1103,23 @@ class CroniterRangeTest(base.TestCase):
         self.assertEqual(res[5].day, 1)
         self.assertEqual(res[-1], datetime(1983, 12, 1))
 
+    def test_1minute_step_float(self):
+        start = datetime(2000, 1, 1, 0, 0)
+        stop =  datetime(2000, 1, 1, 0, 1)
+        res = list(croniter_range(start, stop, '* * * * *', ret_type=float))
+        self.assertEqual(len(res), 2)
+        self.assertEqual(res[0], 946684800.0)
+        self.assertEqual(res[-1] - res[0], 60)
+
+    def test_auto_ret_type(self):
+        data = [
+            (datetime(2019, 1, 1), datetime(2020, 1, 1), datetime),
+            (1552252218.0, 1591823311.0, float),
+        ]
+        for start, stop, rtype in data:
+            ret = list(croniter_range(start, stop, "0 0 * * *"))
+            self.assertIsInstance(ret[0], rtype)
+
     def test_input_type_exceptions(self):
         dt_start1 = datetime(2019, 1, 1)
         dt_stop1 = datetime(2020, 1, 1)
@@ -1110,13 +1127,7 @@ class CroniterRangeTest(base.TestCase):
         f_stop1 = 1591823311.0
         # Mix start/stop types
         with self.assertRaises(TypeError):
-            list(croniter_range(dt_start1, f_stop1, "0 * * * *"))
-
-        # Mix return and input type
-        with self.assertRaises(TypeError):
-            list(croniter_range(dt_start1, dt_stop1, "0 * * * *", ret_type=float))
-        with self.assertRaises(TypeError):
-            list(croniter_range(f_start1, f_stop1, "0 * * * *", ret_type=datetime))
+            list(croniter_range(dt_start1, f_stop1, "0 * * * *"), ret_type=datetime)
 
     def test_timezone_mismatch_exceptions(self):
         cron_expr = "0 * * * *"

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1128,6 +1128,8 @@ class CroniterRangeTest(base.TestCase):
         # Mix start/stop types
         with self.assertRaises(TypeError):
             list(croniter_range(dt_start1, f_stop1, "0 * * * *"), ret_type=datetime)
+        with self.assertRaises(TypeError):
+            list(croniter_range(f_start1, dt_stop1, "0 * * * *"))
 
     def test_timezone_mismatch_exceptions(self):
         cron_expr = "0 * * * *"

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1140,6 +1140,20 @@ class CroniterRangeTest(base.TestCase):
         self.assertNotEqual(res[0].tzinfo, res[-1].tzinfo)
         self.assertEqual(len(res), 12)
 
+    def test_extra_hour_day_prio(self):
+        def datetime_tz(*args, tzinfo=None):
+            """ Defined this in another branch.  single-use-version """
+            return tzinfo.localize(datetime(*args))
+        tz = pytz.timezone("US/Eastern")
+        cron = "0 3 * * *"
+        start = datetime_tz(2020, 3, 7, tzinfo=tz)
+        end = datetime_tz(2020, 3, 11, tzinfo=tz)
+        ret = [ i.isoformat() for i in croniter_range(start, end, cron) ]
+        self.assertEqual(ret, [
+            "2020-03-07T03:00:00-05:00",
+            "2020-03-08T03:00:00-04:00",
+            "2020-03-09T03:00:00-04:00",
+            "2020-03-10T03:00:00-04:00"])
 
 
 if __name__ == '__main__':

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1131,22 +1131,14 @@ class CroniterRangeTest(base.TestCase):
         with self.assertRaises(TypeError):
             list(croniter_range(f_start1, dt_stop1, "0 * * * *"))
 
-    def test_timezone_mismatch_exceptions(self):
-        cron_expr = "0 * * * *"
-        tz1 = pytz.timezone("US/Eastern")
-        tz2 = pytz.timezone("Europe/Athens")
-
-        # With and without a timezone combos
-        with self.assertRaises(ValueError):
-            list(croniter_range(datetime(2020,1,1, tzinfo=tz1),
-                                datetime(2020,1,1), cron_expr))
-        with self.assertRaises(ValueError):
-            list(croniter_range(datetime(2020,1,1),
-                                datetime(2020,1,1, tzinfo=tz2), cron_expr))
-        # Mismatch timezones
-        with self.assertRaises(ValueError):
-            list(croniter_range(datetime(2020,1,1, tzinfo=tz1),
-                                datetime(2020,1,1, tzinfo=tz2), cron_expr))
+    def test_timezone_dst(self):
+        """ Test across DST transition, which technially is a timzone change. """
+        tz = pytz.timezone("US/Eastern")
+        start = tz.localize(datetime(2020, 10, 30))
+        stop =  tz.localize(datetime(2020, 11, 10))
+        res = list(croniter_range(start, stop, '0 0 * * *'))
+        self.assertNotEqual(res[0].tzinfo, res[-1].tzinfo)
+        self.assertEqual(len(res), 12)
 
 
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1141,8 +1141,9 @@ class CroniterRangeTest(base.TestCase):
         self.assertEqual(len(res), 12)
 
     def test_extra_hour_day_prio(self):
-        def datetime_tz(*args, tzinfo=None):
+        def datetime_tz(*args, **kw):
             """ Defined this in another branch.  single-use-version """
+            tzinfo = kw.pop("tzinfo")
             return tzinfo.localize(datetime(*args))
         tz = pytz.timezone("US/Eastern")
         cron = "0 3 * * *"


### PR DESCRIPTION
Adds a helper function to the croniter class called `croniter_range()` which allows a `range(start,stop,step)` like behavior with datetime objects where `step` is a cron expression.

I originally wrote this for my own use case and I thought maybe other would find it useful for croniter with a built-in termination (stop time) condition.

Unittest and README are updated.

The code is a bit harder to read that I would like, and mostly this is due to the fact that inputs and outputs can be datetime or float, and they can be used interchangeably.  But before making any other cleanup I wanted to find out if this is something you'd be interested in adding to croniter.