### PR TITLE
Optimization for poorly written cron expression

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -69,6 +69,15 @@ class croniter(object):
         {},
     )
 
+    LEN_MEANS_ALL = (
+        60,
+        24,
+        31,
+        12,
+        7,
+        60
+    )
+
     bad_length = 'Exactly 5 or 6 columns has to be specified for iterator' \
                  'expression.'
 
@@ -569,7 +578,11 @@ class croniter(object):
                             nth_weekday_of_month[t] = set()
                         nth_weekday_of_month[t].add(int(nth))
 
+            res = set(res)
             res = natsort.natsorted(res)
+            if len(res) == cls.LEN_MEANS_ALL[i]:
+                res = ['*']
+
             expanded.append(['*'] if (len(res) == 1
                                       and res[0] == '*')
                             else res)


### PR DESCRIPTION
This PR includes some code that I've been running internally inside my own project using croniter.  Since my use-case requires end-users (non-cron-experts) to write their own cron expressions, sometimes you end up with things like:

```59 23 * 1 wed,fri,mon-thu,tue,tue```

Croniter currently doesn't attempt to remove duplicates (like the 3 Tuesdays in the DOW field). 
 Similarly the hour field in:

```30 1-12,0,10-23 15-21 * fri```

Can be reduced to simply `*`.

This PR addresses these two situations resulting in a slightly optimized internal representations of these cron expressions.  Hopefully others can benefit from these (rather small) optimizations.