### PR TITLE
Support for more than 1y between matches (Issue 145)

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 0.3.35 (unreleased)
 -------------------
 
+- Add a new initializaton paramter ``max_years_between_matches`` to support finding the next/previous date beyond the default 1 year window, if so desired.  Updated README to include additional notes and example of this usage.
+- The ``croniter_range()`` function was updated to automatically determines the appropriate ``max_years_between_matches`` value, this preventing handling of the ``CroniterBadDateError`` exception.
+- Updated exception handling classes:  ``CroniterBadDateError`` now only* applies during date finding operations (next/prev), and all parsing errors can now be caught using ``CroniterBadCronError``.  The ``CroniterNotAlphaError`` exception is now a subclass of ``CroniterBadCronError``.  A breif description of each exception class was added as an inline docstring.
+- Updated iterable interfaces to replace the ``CroniterBadDateError`` with ``StopIteration`` if (and only if) the ``max_years_between_matches`` argument is provided.  The rationale here is that if the user has specified the max tollernace between matches, then there's no need to further inform them of no additional matches.  Just stop the iteration.  This also keeps backwards compatibility.
 - Nothing changed yet.
 
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,11 +4,14 @@ Changelog
 0.3.35 (unreleased)
 -------------------
 
-- Add a new initializaton paramter ``max_years_between_matches`` to support finding the next/previous date beyond the default 1 year window, if so desired.  Updated README to include additional notes and example of this usage.
+- Add a new initializaton paramter ``max_years_between_matches`` to support finding the next/previous date beyond the default 1 year window, if so desired.  Updated README to include additional notes and example of this usage.  Fixes #145.
+  [Kintyre]
 - The ``croniter_range()`` function was updated to automatically determines the appropriate ``max_years_between_matches`` value, this preventing handling of the ``CroniterBadDateError`` exception.
+  [Kintyre]
 - Updated exception handling classes:  ``CroniterBadDateError`` now only* applies during date finding operations (next/prev), and all parsing errors can now be caught using ``CroniterBadCronError``.  The ``CroniterNotAlphaError`` exception is now a subclass of ``CroniterBadCronError``.  A breif description of each exception class was added as an inline docstring.
+  [Kintyre]
 - Updated iterable interfaces to replace the ``CroniterBadDateError`` with ``StopIteration`` if (and only if) the ``max_years_between_matches`` argument is provided.  The rationale here is that if the user has specified the max tollernace between matches, then there's no need to further inform them of no additional matches.  Just stop the iteration.  This also keeps backwards compatibility.
-- Nothing changed yet.
+  [Kintyre]
 - Minor docs update
   [Kintyre]
 

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -22,18 +22,22 @@ VALID_LEN_EXPRESSION = [5, 6]
 UNDEFINED = object()
 
 class CroniterError(ValueError):
+    """ General top-level Cronier base exception """
     pass
 
 
 class CroniterBadCronError(CroniterError):
+    """ Syntax, unknown value, or range error within a cron expression """
     pass
 
 
 class CroniterBadDateError(CroniterError):
+    """ Unable to find next/prev timestamp match """
     pass
 
 
-class CroniterNotAlphaError(CroniterError):
+class CroniterNotAlphaError(CroniterBadCronError):
+    """ Cron syntax contains an invalid day or month abreviation """
     pass
 
 
@@ -523,7 +527,7 @@ class croniter(object):
                 if i == 4:
                     e, sep, nth = str(e).partition('#')
                     if nth and not re.match(r'[1-5]', nth):
-                        raise CroniterBadDateError(
+                        raise CroniterBadCronError(
                             "[{0}] is not acceptable".format(expr_format))
 
                 t = re.sub(r'^\*(\/.+)$', r'%d-%d\1' % (
@@ -555,7 +559,7 @@ class croniter(object):
                             # handle -Sun notation -> 7
                             high = '7'
                         else:
-                            raise CroniterBadDateError(
+                            raise CroniterBadCronError(
                                 "[{0}] is not acceptable".format(expr_format))
 
                     low, high, step = map(int, [low, high, step])

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1182,6 +1182,26 @@ class CroniterRangeTest(base.TestCase):
             "2020-03-09T03:00:00-04:00",
             "2020-03-10T03:00:00-04:00"])
 
+    def test_issue145_getnext(self):
+        start = datetime(2020, 9, 24)
+        cron = "0 13 8 1,4,7,10 wed"
+        with self.assertRaises(CroniterBadDateError):
+            it = croniter(cron, start, day_or=False)
+            it.get_next()
+
+    def test_issue145_range(self):
+        cron = "0 13 8 1,4,7,10 wed"
+        matches = list(croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, day_or=False))
+        self.assertEqual(len(matches), 3)
+        self.assertEqual(matches[0], datetime(2020, 1, 8, 13))
+        self.assertEqual(matches[1], datetime(2020, 4, 8, 13))
+        self.assertEqual(matches[2], datetime(2020, 7, 8, 13))
+
+        # No matches in this time range
+        matches = list(croniter_range(datetime(2020, 9, 30), datetime(2020, 10, 30), cron, day_or=False))
+        self.assertEqual(len(matches), 0)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1205,6 +1205,40 @@ class CroniterRangeTest(base.TestCase):
         matches = list(croniter_range(datetime(2020, 9, 30), datetime(2020, 10, 30), cron, day_or=False))
         self.assertEqual(len(matches), 0)
 
+    def test_explicit_year_forward(self):
+        start = datetime(2020, 9, 24)
+        cron = "0 13 8 1,4,7,10 wed"
+
+        # Expect exception because no explict range was provided.  Therefore, the caller should be made aware that an implicit limit was hit.
+        iterable = croniter(cron, start, day_or=False).all_next()
+        with self.assertRaises(CroniterBadDateError):
+            next(iterable)
+
+        iterable = croniter(cron, start, day_or=False, max_years_between_matches=5).all_next(datetime)
+        n = next(iterable)
+        self.assertEqual(n, datetime(2025, 1, 8, 13))
+
+        # If the explictly given lookahead isn't enough to reach the next date, that's fine.  The caller specified the maximum gap, so no just stop iteration
+        iterable = croniter(cron, start, day_or=False, max_years_between_matches=2).all_next(datetime)
+        with self.assertRaises(StopIteration):
+            next(iterable)
+
+    def test_explicit_year_reverse(self):
+        start = datetime(2025, 1, 8)
+        cron = "0 13 8 1,4,7,10 wed"
+
+        iterable = croniter(cron, start, day_or=False).all_prev()
+        with self.assertRaises(CroniterBadDateError):
+            next(iterable)
+
+        iterable = croniter(cron, start, day_or=False, max_years_between_matches=5).all_prev(datetime)
+        n = next(iterable)
+        self.assertEqual(n, datetime(2020, 7, 8, 13))
+
+        iterable = croniter(cron, start, day_or=False, max_years_between_matches=2).all_prev()
+        with self.assertRaises(StopIteration):
+            next(iterable)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1183,11 +1183,15 @@ class CroniterRangeTest(base.TestCase):
             "2020-03-10T03:00:00-04:00"])
 
     def test_issue145_getnext(self):
+        # Example of quarterly event cron schedule
         start = datetime(2020, 9, 24)
         cron = "0 13 8 1,4,7,10 wed"
         with self.assertRaises(CroniterBadDateError):
             it = croniter(cron, start, day_or=False)
             it.get_next()
+        # New functionality (0.3.35) allowing croniter to find spare matches of cron patterns across multiple years
+        it = croniter(cron, start, day_or=False, max_years_between_matches=5)
+        self.assertEqual(it.get_next(datetime), datetime(2025, 1, 8, 13))
 
     def test_issue145_range(self):
         cron = "0 13 8 1,4,7,10 wed"
@@ -1197,10 +1201,9 @@ class CroniterRangeTest(base.TestCase):
         self.assertEqual(matches[1], datetime(2020, 4, 8, 13))
         self.assertEqual(matches[2], datetime(2020, 7, 8, 13))
 
-        # No matches in this time range
+        # No matches within this range; therefore expect empty list
         matches = list(croniter_range(datetime(2020, 9, 30), datetime(2020, 10, 30), cron, day_or=False))
         self.assertEqual(len(matches), 0)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Regarding https://github.com/taichino/croniter/issues/145

A full summary of changes provided in the CHANGES.rst file, with additional details in the git commit log and README.   Those are quite verbose so I won't repeat it all again here.  I've tried to split these changes out into reasonable sized commits in case you'd like to veto any of the changes.

I'm not sold on the argument name `max_years_between_matches`, which feels a bit verbose to me.  But it seemed like a good enough starting point.  ;-)

I've tweaked the exception class handling a bit, so please ensure I'm not missing something about the original intention.  I think this is more consistent now, but I could misunderstanding.