### PR TITLE
Fix _expand to reject expressions with an empty step

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -15,8 +15,7 @@ import natsort
 from future.utils import raise_from
 
 
-step_search_re = re.compile(r'^([^-]+)-([^-/]+)(/(.*))?$')
-search_re = re.compile(r'^([^-]+)-([^-/]+)(/(.*))?$')
+step_search_re = re.compile(r'^([^-]+)-([^-/]+)(/(\d+))?$')
 only_int_re = re.compile(r'^\d+$')
 any_int_re = re.compile(r'^\d+')
 star_or_int_re = re.compile(r'^(\d+|\*)$')
@@ -554,13 +553,18 @@ class croniter(object):
                         raise CroniterBadCronError(
                             "[{0}] is not acceptable".format(expr_format))
 
+                # Before matching step_search_re, normalize "*" to "{min}-{max}".
+                # Example: in the minute field, "*/5" normalizes to "0-59/5"
                 t = re.sub(r'^\*(\/.+)$', r'%d-%d\1' % (
                     cls.RANGES[i][0],
                     cls.RANGES[i][1]),
                     str(e))
-                m = search_re.search(t)
+                m = step_search_re.search(t)
 
                 if not m:
+                    # Before matching step_search_re,
+                    # normalize "{start}/{step}" to "{start}-{max}/{step}".
+                    # Example: in the minute field, "10/5" normalizes to "10-59/5"
                     t = re.sub(r'^(.+)\/(.+)$', r'\1-%d/\2' % (
                         cls.RANGES[i][1]),
                         str(e))

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -288,6 +288,7 @@ class CroniterTest(base.TestCase):
         self.assertRaises(ValueError, croniter, '-90 * * * *')
         self.assertRaises(ValueError, croniter, 'a * * * *')
         self.assertRaises(ValueError, croniter, '* * * janu-jun *')
+        self.assertRaises(ValueError, croniter, '0-10/ * * * *')
         self.assertRaises(CroniterBadCronError, croniter, "0-1& * * * *", datetime.now())
 
     def testSundayToThursdayWithAlphaConversion(self):


### PR DESCRIPTION
This is in relation to https://github.com/taichino/croniter/issues/157

This PR fixes _expand to reject expressions with an empty step, like this one:  `0-10/ * * * *`

Removed search_re, as it is identical to step_search_re.

Tightened step_search_re: the "/{step}" component is optional, but if it *is* present, {step} must consist of one or more digits.