### PR TITLE
Update _expand to lowercase each component of the expression

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -93,7 +93,6 @@ class croniter(object):
                  day_or=True, max_years_between_matches=None, is_prev=False):
         self._ret_type = ret_type
         self._day_or = day_or
-        self._expr_format = expr_format
 
         self._max_years_btw_matches_explicitly_set = (
             max_years_between_matches is not None)
@@ -117,7 +116,7 @@ class croniter(object):
     @classmethod
     def _alphaconv(cls, index, key, expressions):
         try:
-            return cls.ALPHACONV[index][key.lower()]
+            return cls.ALPHACONV[index][key]
         except KeyError:
             raise CroniterNotAlphaError(
                 "[{0}] is not acceptable".format(" ".join(expressions)))
@@ -531,7 +530,10 @@ class croniter(object):
 
     @classmethod
     def _expand(cls, expr_format):
-        expressions = expr_format.split()
+        # Split the expression in components, and normalize L -> l, MON -> mon,
+        # etc. Keep expr_format untouched so we can use it in the exception
+        # messages.
+        expressions = [e.lower() for e in expr_format.split()]
 
         if len(expressions) not in VALID_LEN_EXPRESSION:
             raise CroniterBadCronError(cls.bad_length)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -6,10 +6,8 @@ from datetime import datetime, timedelta
 from functools import partial
 from time import sleep
 import pytz
-import croniter as cr
 from croniter import croniter, croniter_range, CroniterBadDateError, CroniterBadCronError, CroniterNotAlphaError
 from croniter.tests import base
-from tzlocal import get_localzone
 import dateutil.tz
 
 
@@ -236,6 +234,16 @@ class CroniterTest(base.TestCase):
         n4 = itr.get_next(datetime)
         self.assertEqual(n4.month, 12)
         self.assertEqual(n4.day, 31)
+
+    def testRangeWithUppercaseLastDayOfMonth(self):
+        base = datetime(2015, 9, 4)
+        itr = croniter('0 0 29-L * *', base)
+        n1 = itr.get_next(datetime)
+        self.assertEqual(n1.month, 9)
+        self.assertEqual(n1.day, 29)
+        n2 = itr.get_next(datetime)
+        self.assertEqual(n2.month, 9)
+        self.assertEqual(n2.day, 30)
 
     def testPrevLastDayOfMonth(self):
         base = datetime(2009, 12, 31, hour=20)


### PR DESCRIPTION
This is in relation to #157. With this change, croniter accepts and correctly handles "* * 10-L * *"

I changed `_expand()` to convert each component of the expression to lowercase. I kept the full expression untouched. This is so that the exception messages would show the original, user-supplied expression, and not an altered version.

Since the components are now guaranteed to be lowercase, I removed the `.lower()` call in `_alphaconv()`.


Other changes:
 * removed unused imports in test_croniter.py
 *  removed unused _expr_format instance variable in the croniter class

