### PR TITLE
Feature:  Enable use of croniter_range() with a subclass of croniter

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 -------------------
 
 - Nothing changed yet.
+- Update ``croniter_range()`` to allow an alternate ``croniter`` class to be used.  Helpful when using a custom class derived from croniter.
+  [Kintyre]
 
 
 1.0.9 (2021-03-23)

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -699,7 +699,8 @@ class croniter(object):
         return (max(tdp, tdt) - min(tdp, tdt)).total_seconds() < 60
 
 
-def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude_ends=False):
+def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude_ends=False,
+                   croniter=croniter):
     """
     Generator that provides all times from start to stop matching the given cron expression.
     If the cron expression matches either 'start' and/or 'stop', those times will be returned as

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -700,7 +700,7 @@ class croniter(object):
 
 
 def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude_ends=False,
-                   croniter=croniter):
+                   _croniter=None):
     """
     Generator that provides all times from start to stop matching the given cron expression.
     If the cron expression matches either 'start' and/or 'stop', those times will be returned as
@@ -709,6 +709,7 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
     You can think of this function as sibling to the builtin range function for datetime objects.
     Like range(start,stop,step), except that here 'step' is a cron expression.
     """
+    _croniter = _croniter or croniter
     auto_rt = datetime.datetime
     if type(start) != type(stop):
         raise TypeError("The start and stop must be same type.  {0} != {1}".
@@ -727,8 +728,8 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
             start += ms1
             stop -= ms1
     year_span = math.floor(abs(stop.year - start.year)) + 1
-    ic = croniter(expr_format, start, ret_type=datetime.datetime, day_or=day_or,
-                  max_years_between_matches=year_span)
+    ic = _croniter(expr_format, start, ret_type=datetime.datetime, day_or=day_or,
+                   max_years_between_matches=year_span)
     # define a continue (cont) condition function and step function for the main while loop
     if start < stop:        # Forward
         def cont(v):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1258,6 +1258,31 @@ class CroniterRangeTest(base.TestCase):
         matches = list(croniter_range(datetime(2020, 9, 30), datetime(2020, 10, 30), cron, day_or=False))
         self.assertEqual(len(matches), 0)
 
+    def test_croniter_range_derived_class(self):
+        # trivial example extending croniter
+
+        class croniter_nosec(croniter):
+            """ Like croniter, but it forbids second-level cron expressions. """
+            @classmethod
+            def expand(cls, expr_format):
+                if len(expr_format.split()) == 6:
+                    raise CroniterBadCronError("Expected 'min hour day mon dow'")
+                return croniter.expand(expr_format)
+
+        cron = "0 13 8 1,4,7,10 wed"
+        matches = list(croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, day_or=False, croniter=croniter_nosec))
+        self.assertEqual(len(matches), 3)
+
+        cron = "0 1 8 1,15,L wed 15,45"
+        with self.assertRaises(CroniterBadCronError):
+            # Should fail using the custom class that forbids the seconds expression
+            croniter_nosec(cron)
+
+        with self.assertRaises(CroniterBadCronError):
+            # Should similiarly fail because it's using the custom classs too
+            i = croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, croniter=croniter_nosec)
+            next(i)
+
     def test_explicit_year_forward(self):
         start = datetime(2020, 9, 24)
         cron = "0 13 8 1,4,7,10 wed"

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1270,7 +1270,7 @@ class CroniterRangeTest(base.TestCase):
                 return croniter.expand(expr_format)
 
         cron = "0 13 8 1,4,7,10 wed"
-        matches = list(croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, day_or=False, croniter=croniter_nosec))
+        matches = list(croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, day_or=False, _croniter=croniter_nosec))
         self.assertEqual(len(matches), 3)
 
         cron = "0 1 8 1,15,L wed 15,45"
@@ -1280,7 +1280,7 @@ class CroniterRangeTest(base.TestCase):
 
         with self.assertRaises(CroniterBadCronError):
             # Should similiarly fail because it's using the custom classs too
-            i = croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, croniter=croniter_nosec)
+            i = croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, _croniter=croniter_nosec)
             next(i)
 
     def test_explicit_year_forward(self):


### PR DESCRIPTION
Allow the `croniter_range()` function to be passed in a specific `croniter` class implementation.  This will allow a developer to extend or customize the `croniter` class and use that with the function without monkey patching the module.