### PR TITLE
Feature:  Support 'L' in day-of-week field  (e.g. Last friday of the month)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,13 @@ A simple example::
     >>> print(iter.get_next(datetime))   # 2010-09-01 04:02:00
     >>> print(iter.get_next(datetime))   # 2010-12-01 04:02:00
     >>> print(iter.get_next(datetime))   # 2011-06-01 04:02:00
+    >>>
     >>> iter = croniter('0 0 * * sat#1,sun#2', base)
     >>> print(iter.get_next(datetime))   # datetime.datetime(2010, 2, 6, 0, 0)
+    >>> iter = croniter('0 0 * * 5#3,L5', base) # 3rd and last Fridays of the month
+    >>> print(iter.get_next(datetime))   # 2010-01-29 00:00:00
+    >>> print(iter.get_next(datetime))   # 2010-02-19 00:00:00
+
 
 All you need to know is how to use the constructor and the ``get_next``
 method, the signature of these methods are listed below::

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,14 @@ Changelog
 1.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for ``L`` in the day_of_week component.  This enable expressions like ``* * * * L4``, which means last Thursday of the month.  This resolves #159.
+  [Kintyre]
+- Create ``CroniterUnsupportedSyntaxError`` exception for situations where CRON syntax may be valid but some combinations of features is not supported.
+  Currently, this is used when the ``day_of_week`` component has a combination of literal values and nth/last syntax at the same time.
+  For example, ``0 0 * * 1,L6`` or ``0 0 * * 15,sat#1`` will both raise this exception because of mixing literal days of the week with nth-weekday or last-weekday syntax.
+  This *may* impact existing cron expressions in prior releases, because ``0 0 * * 15,sat#1`` was previously allowed but incorrectly handled.
+  [Kintyre]
+
 - Update ``croniter_range()`` to allow an alternate ``croniter`` class to be used.  Helpful when using a custom class derived from croniter.
   [Kintyre]
 

--- a/src/croniter/__init__.py
+++ b/src/croniter/__init__.py
@@ -5,6 +5,7 @@ from .croniter import (
     croniter_range,
     CroniterBadDateError,  # noqa
     CroniterBadCronError,  # noqa
-    CroniterNotAlphaError  # noqa
+    CroniterNotAlphaError, # noqa
+    CroniterUnsupportedSyntaxError, #noqa
 )  # noqa
 croniter.__name__  # make flake8 happy

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -129,6 +129,7 @@ class croniter(object):
         self.dst_start_time = None
         self.cur = None
         self.set_current(start_time)
+
         self.expanded, self.nth_weekday_of_month = self.expand(expr_format)
         self._is_prev = is_prev
 
@@ -222,7 +223,8 @@ class croniter(object):
             else:
                 result = t1 if t1 > t2 else t2
         else:
-            result = self._calc(self.cur, expanded, nth_weekday_of_month, is_prev)
+            result = self._calc(self.cur, expanded,
+                                nth_weekday_of_month, is_prev)
 
         # DST Handling for cron job spanning accross days
         dtstarttime = self._timestamp_to_datetime(self.dst_start_time)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1128,7 +1128,6 @@ class CroniterTest(base.TestCase):
     def test_lwom_friday(self):
         it = croniter("0 0 * * L5", datetime(1987, 1, 15), ret_type=datetime)
         items = [next(it) for i in range(12)]
-        self.maxDiff = 1000
         self.assertListEqual(items, [
             datetime(1987, 1, 30),
             datetime(1987, 2, 27),
@@ -1148,7 +1147,6 @@ class CroniterTest(base.TestCase):
         # This works with +/- 'days=1' in proc_day_of_week_last() and I don't know WHY?!?
         it = croniter("0 1,5 * * L5", datetime(1987, 1, 15), ret_type=datetime)
         items = [next(it) for i in range(12)]
-        self.maxDiff = 1000
         self.assertListEqual(items, [
             datetime(1987, 1, 30, 1),
             datetime(1987, 1, 30, 5),
@@ -1167,7 +1165,6 @@ class CroniterTest(base.TestCase):
     def test_lwom_friday_2xh_2xm(self):
         it = croniter("0,30 1,5 * * L5", datetime(1987, 1, 15), ret_type=datetime)
         items = [next(it) for i in range(12)]
-        self.maxDiff = 1000
         self.assertListEqual(items, [
             datetime(1987, 1, 30, 1, 0),
             datetime(1987, 1, 30, 1, 30),
@@ -1186,7 +1183,6 @@ class CroniterTest(base.TestCase):
     def test_lwom_saturday_rev(self):
         it = croniter("0 0 * * L6", datetime(2017, 12, 31), ret_type=datetime, is_prev=True)
         items = [next(it) for i in range(12)]
-        self.maxDiff = 1000
         self.assertListEqual(items, [
             datetime(2017, 12, 30),
             datetime(2017, 11, 25),
@@ -1205,7 +1201,6 @@ class CroniterTest(base.TestCase):
     def test_lwom_tue_thu(self):
         it = croniter("0 0 * * L2,L4", datetime(2016, 6, 1), ret_type=datetime)
         items = [next(it) for i in range(10)]
-        self.maxDiff = 1000
         self.assertListEqual(items, [
             datetime(2016, 6, 28),
             datetime(2016, 6, 30),
@@ -1220,7 +1215,7 @@ class CroniterTest(base.TestCase):
         ])
 
     def test_hash_mixup_all_fri_3rd_sat(self):
-        # It appears that it's not possible to MIX a literal dow with a  `dow#n` format
+        # It appears that it's not possible to MIX a literal dow with a `dow#n` format
         cron_a = "0 0 * * 6#3"
         cron_b = "0 0 * * 5"
         cron_c = "0 0 * * 5,6#3"

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1103,19 +1103,31 @@ class CroniterTest(base.TestCase):
             '2020-03-29T02:01:00+02:00',
             '2020-03-29T03:01:00+02:00'])
 
-    def test_wdom_core_simple(self):
-        f = croniter._get_last_weekday_of_month
+
+    def test_nth_wday_simple(self):
+        f = lambda y,m,w: croniter._get_nth_weekday_of_month(y,m,w)
         sun, mon, tue, wed, thu, fri, sat = range(7)
-        self.assertEqual(f(2021, 3, sun), 28)
-        self.assertEqual(f(2035, 12, sat), 29)
-        self.assertEqual(f(2000, 1, fri), 28)
-        self.assertEqual(f(2014, 8, mon), 25)
-        self.assertEqual(f(2022, 2, tue), 22)
-        self.assertEqual(f(1999, 10, wed), 27)
-        self.assertEqual(f(2005, 7, thu), 28)
+
+        self.assertEqual(f(2000, 1, mon), (3, 10, 17, 24, 31))
+        self.assertEqual(f(2000, 2, tue), (1, 8, 15, 22, 29)) # Leap year
+        self.assertEqual(f(2000, 3, wed), (1, 8, 15, 22, 29))
+        self.assertEqual(f(2000, 4, thu), (6, 13, 20, 27))
+        self.assertEqual(f(2000, 2, fri), (4, 11, 18, 25))
+        self.assertEqual(f(2000, 2, sat), (5, 12, 19, 26))
+
+    def test_nth_as_last_wday_simple(self):
+        f = lambda y,m,w: croniter._get_nth_weekday_of_month(y,m,w)[-1]
+        sun, mon, tue, wed, thu, fri, sat = range(7)
+        self.assertEqual(f(2000, 2, tue), 29)
+        self.assertEqual(f(2000, 2, sun), 27)
+        self.assertEqual(f(2000, 2, mon), 28)
+        self.assertEqual(f(2000, 2, wed), 23)
+        self.assertEqual(f(2000, 2, thu), 24)
+        self.assertEqual(f(2000, 2, fri), 25)
+        self.assertEqual(f(2000, 2, sat), 26)
 
     def test_wdom_core_leap_year(self):
-        f = croniter._get_last_weekday_of_month
+        f = lambda y,m,w: croniter._get_nth_weekday_of_month(y,m,w)[-1]
         sun, mon, tue, wed, thu, fri, sat = range(7)
         self.assertEqual(f(2000, 2, tue), 29)
         self.assertEqual(f(2000, 2, sun), 27)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1308,6 +1308,18 @@ class CroniterTest(base.TestCase):
         self.assertListEqual(getn(cron_b, 3), expect_b)
         self.assertListEqual(getn(cron_c, 5), expect_c)
 
+    def test_nth_out_of_range(self):
+        with self.assertRaises(CroniterBadCronError):
+            croniter("0 0 * * 1#7")
+        with self.assertRaises(CroniterBadCronError):
+            croniter("0 0 * * 1#0")
+
+    def test_last_out_of_range(self):
+        with self.assertRaises(CroniterBadCronError):
+            croniter("0 0 * * L-1")
+        with self.assertRaises(CroniterBadCronError):
+            croniter("0 0 * * L8")
+
     def test_issue_142_dow(self):
         ret = []
         for i in range(1, 31):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1102,27 +1102,26 @@ class CroniterTest(base.TestCase):
             '2020-03-29T03:01:00+02:00'])
 
     def test_last_wdom_simple(self):
-        f = croniter.find_day_of_last_dow
+        f = croniter._get_last_weekday_of_month
         sun, mon, tue, wed, thu, fri, sat = range(7)
-        self.assertEqual(f(datetime(2021, 3, 6), sun), 28)
-        self.assertEqual(f(datetime(2035, 12, 31), sat), 29)
-        self.assertEqual(f(datetime(2000, 1, 1), fri), 28)
-        self.assertEqual(f(datetime(2014, 8, 15), mon), 25)
-        self.assertEqual(f(datetime(2022, 2, 19), tue), 22)
-        self.assertEqual(f(datetime(1999, 10, 10), wed), 27)
-        self.assertEqual(f(datetime(2005, 7, 19), thu), 28)
+        self.assertEqual(f(2021, 3, sun), 28)
+        self.assertEqual(f(2035, 12, sat), 29)
+        self.assertEqual(f(2000, 1, fri), 28)
+        self.assertEqual(f(2014, 8, mon), 25)
+        self.assertEqual(f(2022, 2, tue), 22)
+        self.assertEqual(f(1999, 10, wed), 27)
+        self.assertEqual(f(2005, 7, thu), 28)
 
     def test_last_wdom_leap_year(self):
-        f = croniter.find_day_of_last_dow
+        f = croniter._get_last_weekday_of_month
         sun, mon, tue, wed, thu, fri, sat = range(7)
-        self.assertEqual(f(datetime(2000, 2, 1), tue), 29)
-        self.assertEqual(f(datetime(2000, 2, 10), tue), 29) # day doesn't matter
-        self.assertEqual(f(datetime(2000, 2, 1), sun), 27)
-        self.assertEqual(f(datetime(2000, 2, 1), mon), 28)
-        self.assertEqual(f(datetime(2000, 2, 1), wed), 23)
-        self.assertEqual(f(datetime(2000, 2, 1), thu), 24)
-        self.assertEqual(f(datetime(2000, 2, 1), fri), 25)
-        self.assertEqual(f(datetime(2000, 2, 1), sat), 26)
+        self.assertEqual(f(2000, 2, tue), 29)
+        self.assertEqual(f(2000, 2, sun), 27)
+        self.assertEqual(f(2000, 2, mon), 28)
+        self.assertEqual(f(2000, 2, wed), 23)
+        self.assertEqual(f(2000, 2, thu), 24)
+        self.assertEqual(f(2000, 2, fri), 25)
+        self.assertEqual(f(2000, 2, sat), 26)
 
     def test_croniter_last_friday(self):
         it = croniter("0 0 * * L5", datetime(1987, 1, 15), ret_type=datetime)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1101,6 +1101,48 @@ class CroniterTest(base.TestCase):
             '2020-03-29T02:01:00+02:00',
             '2020-03-29T03:01:00+02:00'])
 
+    def test_last_wdom_simple(self):
+        f = croniter.find_day_of_last_dow
+        sun, mon, tue, wed, thu, fri, sat = range(7)
+        self.assertEqual(f(datetime(2021, 3, 6), sun), 28)
+        self.assertEqual(f(datetime(2035, 12, 31), sat), 29)
+        self.assertEqual(f(datetime(2000, 1, 1), fri), 28)
+        self.assertEqual(f(datetime(2014, 8, 15), mon), 25)
+        self.assertEqual(f(datetime(2022, 2, 19), tue), 22)
+        self.assertEqual(f(datetime(1999, 10, 10), wed), 27)
+        self.assertEqual(f(datetime(2005, 7, 19), thu), 28)
+
+    def test_last_wdom_leap_year(self):
+        f = croniter.find_day_of_last_dow
+        sun, mon, tue, wed, thu, fri, sat = range(7)
+        self.assertEqual(f(datetime(2000, 2, 1), tue), 29)
+        self.assertEqual(f(datetime(2000, 2, 10), tue), 29) # day doesn't matter
+        self.assertEqual(f(datetime(2000, 2, 1), sun), 27)
+        self.assertEqual(f(datetime(2000, 2, 1), mon), 28)
+        self.assertEqual(f(datetime(2000, 2, 1), wed), 23)
+        self.assertEqual(f(datetime(2000, 2, 1), thu), 24)
+        self.assertEqual(f(datetime(2000, 2, 1), fri), 25)
+        self.assertEqual(f(datetime(2000, 2, 1), sat), 26)
+
+    def test_croniter_last_friday(self):
+        it = croniter("0 0 * * L5", datetime(1987, 1, 15), ret_type=datetime)
+        items = [next(it) for i in range(12)]
+        self.maxDiff = 100000
+        self.assertListEqual(items, [
+            datetime(1987, 1, 30),
+            datetime(1987, 2, 27),
+            datetime(1987, 3, 27),
+            datetime(1987, 4, 24),
+            datetime(1987, 5, 29),
+            datetime(1987, 6, 26),
+            datetime(1987, 7, 31),
+            datetime(1987, 8, 28),
+            datetime(1987, 9, 25),
+            datetime(1987, 10, 30),
+            datetime(1987, 11, 27),
+            datetime(1987, 12, 25),
+        ])
+
     def test_issue_142_dow(self):
         ret = []
         for i in range(1, 31):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta
 from functools import partial
 from time import sleep
 import pytz
-from croniter import croniter, CroniterBadDateError, CroniterBadCronError, CroniterNotAlphaError
+from croniter import (croniter, CroniterBadDateError,  CroniterBadCronError,
+                      CroniterNotAlphaError, CroniterUnsupportedSyntaxError)
 from croniter.tests import base
 import dateutil.tz
 
@@ -1218,7 +1219,6 @@ class CroniterTest(base.TestCase):
             datetime(2016, 10, 27),
         ])
 
-    @unittest.expectedFailure
     def test_hash_mixup_all_fri_3rd_sat(self):
         # It appears that it's not possible to MIX a literal dow with a  `dow#n` format
         cron_a = "0 0 * * 6#3"
@@ -1238,10 +1238,9 @@ class CroniterTest(base.TestCase):
             return [next(it) for i in range(n)]
         self.assertListEqual(getn(cron_a, 1), expect_a)
         self.assertListEqual(getn(cron_b, 4), expect_b)
-        #with self.assertRaises(CroniterBadCronError):
-        self.assertListEqual(getn(cron_c, 5), expect_c)
+        with self.assertRaises(CroniterUnsupportedSyntaxError):
+            self.assertListEqual(getn(cron_c, 5), expect_c)
 
-    @unittest.expectedFailure
     def test_lwom_mixup_all_fri_last_sat(self):
         # Based on the failure of test_hash_mixup_all_fri_3rd_sat, we should expect this to fail too as this implementation simply extends nth_weekday_of_month
         cron_a = "0 0 * * L6"
@@ -1261,8 +1260,8 @@ class CroniterTest(base.TestCase):
             return [next(it) for i in range(n)]
         self.assertListEqual(getn(cron_a, 1), expect_a)
         self.assertListEqual(getn(cron_b, 4), expect_b)
-        #with self.assertRaises(CroniterBadCronError):
-        self.assertListEqual(getn(cron_c, 5), expect_c)
+        with self.assertRaises(CroniterUnsupportedSyntaxError):
+            self.assertListEqual(getn(cron_c, 5), expect_c)
 
     def test_lwom_mixup_firstlast_sat(self):
         # First saturday, last saturday


### PR DESCRIPTION
@kiorky, I've taken a stab at adding support for this in the core croniter class as a follow up to https://github.com/taichino/croniter/issues/159.  It wasn't quite as difficult as I thought it may be, though there are a items worth considering:

**UPDATED**

1.  Fundamentally, this implementation piggybacks on the `w#n` (nth_weekday_of_month) functionality.  Instead of storing the weekday number (nth), it simply stores the letter `l` in the same location.
1. During development, I seem to have found some unsupported uses case.  The dow field now supports 3 different types of values:   (1) literals: string/numeric; with ranges/steps, (2) nth weekday of month,  (`wed#3` third wednesday), and (3) last weekday per month, (last wednesday of the month `L3`).   It appears that mixing the relatively straightforward type 1 literals, with either type 2 or 3 (which have a strongly shared code path) does not result in correct output.   I've created 2 unittests demonstrating the issues I've found, but since they already existed I didn't want to hold up the new feature on tracking it down.  (Look for `CroniterUnsupportedSyntaxError` in the code)

I made new exception class called `CroniterUnsupportedSyntaxError`  (It's isolated in its own commit, if you don't like the idea).  The rationale is this:  whenever there are known fringe corner cases that can be detected, but are not (or cannot be) fully supported, this exception could be used.   I think this is better than either (1) throwing `CroniterBadCronError` because technically that makes the use think that it's their syntax, when not's not fully accurate, or (2) ignoring the situation and continuing at the risk of returning incorrect results.   Ideally, these wouldn't exist, but there's such a massive number of permutations possible with the cron syntax that it seems like this may come up at other times too.

Thanks again for your time and consideration!