### PR TITLE
fix get_prev bug: bad case:0 6 30 3 *

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -530,7 +530,9 @@ class croniter(object):
             if c <= range_val:
                 candidate = c
                 break
-
+        if condidate > range_val:
+            # fix crontab "0 6 30 3 *" condidates only a element, then get_prev error return 2021-03-02 06:00:00, 
+            return -x
         return (candidate - x - range_val)
 
     def is_leap(self, year):

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -530,9 +530,10 @@ class croniter(object):
             if c <= range_val:
                 candidate = c
                 break
-        if condidate > range_val:
-            # fix crontab "0 6 30 3 *" condidates only a element, then get_prev error return 2021-03-02 06:00:00, 
-            return -x
+        if candidate > range_val:
+            # fix crontab "0 6 30 3 *" condidates only a element,
+            # then get_prev error return 2021-03-02 06:00:00
+            return - x
         return (candidate - x - range_val)
 
     def is_leap(self, year):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1101,6 +1101,16 @@ class CroniterTest(base.TestCase):
             '2020-03-29T02:01:00+02:00',
             '2020-03-29T03:01:00+02:00'])
 
+    def test_issue_47(self):
+        base = datetime(2021, 3, 30, 4, 0)
+        itr = croniter('0 6 30 3 *', base)
+        prev1 = itr.get_prev(datetime)
+        self.assertEqual(prev1.year, base.year-1)
+        self.assertEqual(prev1.month, 3)
+        self.assertEqual(prev1.day, 30)
+        self.assertEqual(prev1.hour, 6)
+        self.assertEqual(prev1.minute, 0)
+
     def test_issue_142_dow(self):
         ret = []
         for i in range(1, 31):


### PR DESCRIPTION
when crontab day only one day, but last month not has the day, example crontab expression: 0 6 30 3 *
then get_prev return error result: 2021-03-02 06:00:00