### PR TITLE
flake8: ignore C901 (Function is too complex)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [flake8]
 max-line-length = 120
-ignore = W504,W503
+ignore = C901,W504,W503
 
 [coverage:run]
 source = .


### PR DESCRIPTION
C901 is normally not checked because max-complexity is not set, but
if the user has max-complexity set in their user-wide .config/flake8,
this will prevent false positives.